### PR TITLE
KiB representation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,13 +39,13 @@ truffle run contract-size --contracts ExampleContract1 ExampleContract2
 
 ### Check maximum contract sizes
 
-The plugin can be used to check that the smart contracts aren't bigger than the allowed maximum contract size of the Ethereum Mainnet (24 kb). For example this can be used, to make a CI/CD pipeline fail, if a contract is bigger than allowed.
+The plugin can be used to check that the smart contracts aren't bigger than the allowed maximum contract size of the Ethereum Mainnet (24 KiB = 24576 bytes). For example this can be used, to make a CI/CD pipeline fail, if a contract is bigger than allowed.
 
 ```bash
 truffle run contract-size --checkMaxSize
 ```
 
-If another size limit than the default one should be checked, it can be given as argument to the option. For example to set the maximum to 48 kb the following command can be used:
+If another size limit than the default one should be checked, it can be given as argument to the option. For example to set the maximum to 48 KiB the following command can be used:
 
 ```bash
 truffle run contract-size --checkMaxSize 48

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-contract-size",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -30,9 +30,9 @@
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
     },
     "acorn": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.0.0.tgz",
-      "integrity": "sha512-PaF/MduxijYYt7unVGRuds1vBC9bFxbNf+VWqhOClfdgy7RlVkQqt610ig1/yxTgsDIfW1cWDel5EBbOy3jdtQ==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.3.1.tgz",
+      "integrity": "sha512-tLc0wSnatxAQHVHUapaHdz72pi9KUyHjq5KyHjGg9Y8Ifdc79pTh2XvI6I1/chZbnM7QtNKzh66ooDogPZSleA==",
       "dev": true
     },
     "acorn-jsx": {
@@ -981,9 +981,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+      "version": "4.17.19",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.19.tgz",
+      "integrity": "sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==",
       "dev": true
     },
     "mimic-fn": {
@@ -1002,18 +1002,18 @@
       }
     },
     "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "dev": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
       "dev": true,
       "requires": {
-        "minimist": "0.0.8"
+        "minimist": "^1.2.5"
       }
     },
     "ms": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "truffle-contract-size",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Displays the size of a truffle contracts in kilobytes",
   "main": "src/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -7,7 +7,8 @@ const readDir = util.promisify(fs.readdir)
 const Table = require('cli-table')
 const yargs = require('yargs')
 
-const DEFAULT_MAX_CONTRACT_SIZE_IN_KB = 24
+// 1 KiB = 1.024 bytes
+const DEFAULT_MAX_CONTRACT_SIZE_IN_KIB = 24
 
 /**
  * Outputs the size of a given smart contract
@@ -43,7 +44,7 @@ module.exports = async (config, done) => {
       done(`Error: deployedBytecode not found in ${contract.file} (it is not a contract json file)`)
     }
 
-    const byteCodeSize = computeByteCodeSizeInKb(contractFile.deployedBytecode)
+    const byteCodeSize = computeByteCodeSizeInKiB(contractFile.deployedBytecode)
 
     table.push([
       contract.name,
@@ -56,11 +57,11 @@ module.exports = async (config, done) => {
   console.log(table.toString())
 
   if (checkMaxSize) {
-    const maxSize = checkMaxSize === true ? DEFAULT_MAX_CONTRACT_SIZE_IN_KB : checkMaxSize
+    const maxSize = checkMaxSize === true ? DEFAULT_MAX_CONTRACT_SIZE_IN_KIB : checkMaxSize
 
     table.forEach(row => {
       if (Number.parseFloat(row[1]) > maxSize) {
-        done(`Contract ${row[0]} is bigger than ${maxSize} kb`)
+        done(`Contract ${row[0]} is bigger than ${maxSize} KiB`)
       }
     })
   }
@@ -70,7 +71,7 @@ module.exports = async (config, done) => {
 
 function configureArgumentParsing () {
   yargs.option('contracts', { describe: 'Only display certain contracts', type: 'array' })
-  yargs.option('checkMaxSize', { describe: 'Returns an error exit code if a contract is bigger than the optional size in kb (default: 24). Must be an integer value' })
+  yargs.option('checkMaxSize', { describe: 'Returns an error exit code if a contract is bigger than the optional size in KiB (default: 24). Must be an integer value' })
   yargs.option('ignoreMocks', { describe: 'Ignores all contracts which names end with "Mock"', type: 'boolean' })
 
   // disable version parameter
@@ -88,15 +89,15 @@ function isValidCheckMaxSize (checkMaxSize) {
   return checkMaxSize === true || !Number.isNaN(checkMaxSize)
 }
 
-function computeByteCodeSizeInKb (byteCode) {
+function computeByteCodeSizeInKiB (byteCode) {
   // -2 to remove 0x from the beginning of the string
   // /2 because one byte consists of two hexadecimal values
-  // /1024 to convert to size from byte to kilo byte
+  // /1024 to convert to size from byte to kibibytes
   return (byteCode.length - 2) / 2 / 1024
 }
 
 function formatByteCodeSize (byteCodeSize) {
-  return `${byteCodeSize.toFixed(2)} kb`
+  return `${byteCodeSize.toFixed(2)} KiB`
 }
 
 async function checkFile (filePath, done) {


### PR DESCRIPTION
Use always KiB instead kb to represent the contract binary size.